### PR TITLE
Hierarchy change

### DIFF
--- a/src/main/docsite/ajax/ajax_get.kt
+++ b/src/main/docsite/ajax/ajax_get.kt
@@ -98,7 +98,7 @@ fun createAjaxGetSection(): Div {
                                 content { emph { +"${weatherData.main!!.temp}"} }
                             })
                 } else {
-                    temperatureSpan.replace( Alert(style = AlertStyle.DANGER) with { +"Location not found" })
+                    temperatureSpan.fade( Alert(style = AlertStyle.DANGER) with { +"Location not found" })
                 }
             }
         }

--- a/src/main/docsite/app.kt
+++ b/src/main/docsite/app.kt
@@ -59,7 +59,6 @@ fun main(args: Array<String>) {
 		topMenu(navbar)
 		content {
 			div {
-				+"Ahoj"
 				br(); br();
 				+divContainer
 			}

--- a/src/main/docsite/app.kt
+++ b/src/main/docsite/app.kt
@@ -59,6 +59,7 @@ fun main(args: Array<String>) {
 		topMenu(navbar)
 		content {
 			div {
+				+"Ahoj"
 				br(); br();
 				+divContainer
 			}

--- a/src/main/docsite/bootstrap/bootstrap.kt
+++ b/src/main/docsite/bootstrap/bootstrap.kt
@@ -6,14 +6,7 @@ import net.yested.bootstrap.row
 import net.yested.bootstrap.pageHeader
 import net.yested.bootstrap.Medium
 
-import jquery.jq
-import jquery.JQuery
-import net.yested.bootstrap.navbar
-import net.yested.ParentComponent
-import net.yested.with
-import net.yested.HTMLParentComponent
 import net.yested.bootstrap.enableScrollSpy
-
 
 fun bootstrapPage(): Div {
 

--- a/src/main/docsite/bootstrap/buttonGroups.kt
+++ b/src/main/docsite/bootstrap/buttonGroups.kt
@@ -19,7 +19,7 @@ fun buttonGroupsSection(id: String): Div {
     val span = Span()
     val btnGroup = ButtonGroup(
                                 size = ButtonSize.DEFAULT,
-                                onSelect = { value -> span.replace("Selected: ${value}")}
+                                onSelect = { value -> span.setContent("Selected: ${value}")}
                             ) with {
                                 button(value = "1", label = { + "Option 1"})
                                 button(value = "2", label = { + "Option 2"})

--- a/src/main/docsite/bootstrap/pagination.kt
+++ b/src/main/docsite/bootstrap/pagination.kt
@@ -32,7 +32,7 @@ Pagination from Bootstrap.
                 }
                 br()
                 h4 { +"Demo" }
-                pagination(count = 6, defaultSelection = 2) { result.replace("Selected: ${it}")}
+                pagination(count = 6, defaultSelection = 2) { result.setContent("Selected: ${it}")}
                 +result
 
             }

--- a/src/main/docsite/bootstrap/select.kt
+++ b/src/main/docsite/bootstrap/select.kt
@@ -30,14 +30,14 @@ fun createSelectSection(id: String): Div {
     val singleSelect = Select<Car>(renderer = { "${it.model} (${it.color})" })
     singleSelect.data = someData
     singleSelect.addOnChangeListener {
-        resultSingleSelect.replace( "Selected: ${singleSelect.selectedItems.first().model}")
+        resultSingleSelect.setContent( "Selected: ${singleSelect.selectedItems.first().model}")
     }
 
     val resultMultiSelect = Div()
     val multiSelect = Select<Car>(multiple = true, size = 4, renderer = { "${it.model} (${it.color})" })
     multiSelect.data = someData
     multiSelect.addOnChangeListener {
-        resultMultiSelect.replace( "Selected: " + multiSelect.selectedItems.map { "${it.model}" }.join(" and "))
+        resultMultiSelect.setContent( "Selected: " + multiSelect.selectedItems.map { "${it.model}" }.join(" and "))
     }
 
     val btn = BtsButton(label = { +"Select Skoda and Ford" }) {

--- a/src/main/kotlin/net/yested/bootstrap/MediaObject.kt
+++ b/src/main/kotlin/net/yested/bootstrap/MediaObject.kt
@@ -1,13 +1,8 @@
 package net.yested.bootstrap
 
-import net.yested.ParentComponent
-import net.yested.HTMLParentComponent
-import net.yested.Div
+import net.yested.HTMLComponent
 import net.yested.with
-import net.yested.bootstrap.ButtonSize
-import net.yested.P
 import net.yested.Anchor
-import net.yested.Component
 import org.w3c.dom.Element
 
 public enum class MediaAlign(val className: String) {
@@ -15,36 +10,37 @@ public enum class MediaAlign(val className: String) {
 	Right : MediaAlign("pull-right")
 }
 
-public class MediaBody() : HTMLParentComponent("div") {
+public class MediaBody() : HTMLComponent("div") {
 
-	private val heading = HTMLParentComponent("h4") with { clazz = "media-heading" }
+	private val heading = HTMLComponent("h4") with { clazz = "media-heading" }
 
 	{
-		setAttribute("class", "media-body")
+		element.setAttribute("class", "media-body")
 	}
 
-	public fun heading(init: HTMLParentComponent.() -> Unit) {
+	public fun heading(init: HTMLComponent.() -> Unit) {
 		heading.init()
-		add(heading)
+		+heading
 	}
 
-	public fun content(init: ParentComponent.() -> Unit) {
+	public fun content(init: HTMLComponent.() -> Unit) {
 		this.init()
 	}
+
 }
 
-public class MediaObject(align: MediaAlign) : HTMLParentComponent("div") {
+public class MediaObject(align: MediaAlign) : HTMLComponent("div") {
 
 	private val media = Anchor() with { clazz = align.className; href = "#" }
 	private val body = MediaBody() with { }
 
 	{
-		setAttribute("class", "media")
-		add(media)
-		add(body)
+		element.setAttribute("class", "media")
+		appendChild(media)
+		appendChild(body)
 	}
 
-	public fun media(init: HTMLParentComponent.() -> Unit) {
+	public fun media(init: HTMLComponent.() -> Unit) {
 		media.init()
 		val childElement = media.element.firstChild as Element
 		val clazz = childElement.getAttribute("class") as String? ?: ""
@@ -56,8 +52,6 @@ public class MediaObject(align: MediaAlign) : HTMLParentComponent("div") {
 	}
 }
 
-public fun HTMLParentComponent.mediaObject(align: MediaAlign, init:MediaObject.() -> Unit) {
-	val mediaObject = MediaObject(align)
-	mediaObject.init()
-	add(mediaObject)
+public fun HTMLComponent.mediaObject(align: MediaAlign, init:MediaObject.() -> Unit) {
+	+(MediaObject(align) with  { init() })
 }

--- a/src/main/kotlin/net/yested/bootstrap/alerts.kt
+++ b/src/main/kotlin/net/yested/bootstrap/alerts.kt
@@ -31,5 +31,4 @@ public class Alert(style: AlertStyle) : Div() {
 }
 
 fun HTMLParentComponent.alert(style: AlertStyle, init:Alert.() -> Unit) =
-    add(
-            Alert(style = style) with { init() } )
+    +(Alert(style = style) with { init() } )

--- a/src/main/kotlin/net/yested/bootstrap/alerts.kt
+++ b/src/main/kotlin/net/yested/bootstrap/alerts.kt
@@ -1,6 +1,6 @@
 package net.yested.bootstrap
 
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.Div
 import net.yested.div
 import net.yested.Anchor
@@ -18,17 +18,17 @@ public enum class AlertStyle(val code:String) {
     DANGER :    AlertStyle("danger")
 }
 
-public class Alert(style: AlertStyle) : Div() {
+public class Alert(style: AlertStyle) : HTMLComponent("div") {
 
     {
         clazz = "alert alert-${style.code}"
     }
 
     override fun a(clazz: String?, href: String?, onclick: (() -> Unit)?, init: Anchor.() -> Unit) {
-        super<Div>.a(clazz?:"alert-link", href, onclick, init)
+        super<HTMLComponent>.a(clazz?:"alert-link", href, onclick, init)
     }
 
 }
 
-fun HTMLParentComponent.alert(style: AlertStyle, init:Alert.() -> Unit) =
+fun HTMLComponent.alert(style: AlertStyle, init:Alert.() -> Unit) =
     +(Alert(style = style) with { init() } )

--- a/src/main/kotlin/net/yested/bootstrap/breadcrumbs.kt
+++ b/src/main/kotlin/net/yested/bootstrap/breadcrumbs.kt
@@ -1,13 +1,11 @@
 package net.yested.bootstrap
 
-import net.yested.HTMLParentComponent
-import net.yested.ParentComponent
+import net.yested.HTMLComponent
 import net.yested.Li
 import net.yested.with
 import net.yested.createElement
 import net.yested.Component
-import net.yested.add
-import net.yested.appendChild
+import net.yested.appendComponent
 
 /**
  * Created by jean on 30.11.2014.
@@ -20,14 +18,14 @@ public class Breadcrumbs : Component {
         element.setAttribute("class", "breadcrumb")
     }
 
-    fun link(href:String? = null, onclick:Function0<Unit>? = null, init:HTMLParentComponent.() -> Unit) {
-        element.add(Li(), {
+    fun link(href:String? = null, onclick:Function0<Unit>? = null, init: HTMLComponent.() -> Unit) {
+        element.appendComponent(Li() with {
             a(href = href, onclick = onclick, init = init)
         })
     }
 
-    fun selected(init: HTMLParentComponent.() -> Unit) {
-        element.add(Li(), {
+    fun selected(init: HTMLComponent.() -> Unit) {
+        element.appendComponent(Li() with {
             clazz = "active"
             init()
         })
@@ -35,8 +33,8 @@ public class Breadcrumbs : Component {
 
 }
 
-public fun HTMLParentComponent.breadcrumbs(init: Breadcrumbs.() -> Unit): Breadcrumbs {
-    val breadcrumbs = Breadcrumbs() with init
+public fun HTMLComponent.breadcrumbs(init: Breadcrumbs.() -> Unit): Breadcrumbs {
+    val breadcrumbs = Breadcrumbs() with  { init() }
     +breadcrumbs
     return breadcrumbs
 }

--- a/src/main/kotlin/net/yested/bootstrap/breadcrumbs.kt
+++ b/src/main/kotlin/net/yested/bootstrap/breadcrumbs.kt
@@ -4,24 +4,30 @@ import net.yested.HTMLParentComponent
 import net.yested.ParentComponent
 import net.yested.Li
 import net.yested.with
+import net.yested.createElement
+import net.yested.Component
+import net.yested.add
+import net.yested.appendChild
 
 /**
  * Created by jean on 30.11.2014.
  */
-public class Breadcrumbs : ParentComponent("ol") {
+public class Breadcrumbs : Component {
+
+    override val element = createElement("ol");
 
     {
-        setAttribute("class", "breadcrumb")
+        element.setAttribute("class", "breadcrumb")
     }
 
     fun link(href:String? = null, onclick:Function0<Unit>? = null, init:HTMLParentComponent.() -> Unit) {
-        add(Li() with {
+        element.add(Li(), {
             a(href = href, onclick = onclick, init = init)
         })
     }
 
     fun selected(init: HTMLParentComponent.() -> Unit) {
-        add(Li() with {
+        element.add(Li(), {
             clazz = "active"
             init()
         })
@@ -30,8 +36,7 @@ public class Breadcrumbs : ParentComponent("ol") {
 }
 
 public fun HTMLParentComponent.breadcrumbs(init: Breadcrumbs.() -> Unit): Breadcrumbs {
-    val breadcrumbs = Breadcrumbs()
-    breadcrumbs.init()
-    this.add(breadcrumbs)
+    val breadcrumbs = Breadcrumbs() with init
+    +breadcrumbs
     return breadcrumbs
 }

--- a/src/main/kotlin/net/yested/bootstrap/buttongroup.kt
+++ b/src/main/kotlin/net/yested/bootstrap/buttongroup.kt
@@ -4,6 +4,9 @@ import net.yested.ParentComponent
 import java.util.ArrayList
 import java.util.HashMap
 import net.yested.HTMLParentComponent
+import net.yested.Component
+import kotlin.js.dom.html.HTMLElement
+import net.yested.createElement
 
 /**
  * Created by jean on 24.12.2014.
@@ -13,13 +16,15 @@ import net.yested.HTMLParentComponent
 <button type="button" class="btn btn-default">Right</button>
 </div>
  */
-public class ButtonGroup(val size: ButtonSize = ButtonSize.DEFAULT, val onSelect:Function1<String, Unit>? = null) : ParentComponent("div") {
+public class ButtonGroup(val size: ButtonSize = ButtonSize.DEFAULT, val onSelect:Function1<String, Unit>? = null) : Component {
+
+    override val element = createElement("div")
 
     private val buttons = HashMap<String, BtsButton>();
 
     {
-        setAttribute("class", "btn-group")
-        setAttribute("role", "group")
+        element.setAttribute("class", "btn-group")
+        element.setAttribute("role", "group")
     }
 
     public var value:String? = null
@@ -42,7 +47,7 @@ public class ButtonGroup(val size: ButtonSize = ButtonSize.DEFAULT, val onSelect
         val button = BtsButton(label = label, look = look, size = size) {
             select(value)
         }
-        add(button)
+        element.appendChild(button)
         buttons.put(value, button)
     }
 

--- a/src/main/kotlin/net/yested/bootstrap/buttongroup.kt
+++ b/src/main/kotlin/net/yested/bootstrap/buttongroup.kt
@@ -1,12 +1,12 @@
 package net.yested.bootstrap
 
-import net.yested.ParentComponent
 import java.util.ArrayList
 import java.util.HashMap
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.Component
 import kotlin.js.dom.html.HTMLElement
 import net.yested.createElement
+import net.yested.appendComponent
 
 /**
  * Created by jean on 24.12.2014.
@@ -43,11 +43,11 @@ public class ButtonGroup(val size: ButtonSize = ButtonSize.DEFAULT, val onSelect
         }
     }
 
-    public fun button(value:String, look: ButtonLook = ButtonLook.DEFAULT, label : HTMLParentComponent.() -> Unit) {
+    public fun button(value:String, look: ButtonLook = ButtonLook.DEFAULT, label : HTMLComponent.() -> Unit) {
         val button = BtsButton(label = label, look = look, size = size) {
             select(value)
         }
-        element.appendChild(button)
+        element.appendComponent(button)
         buttons.put(value, button)
     }
 

--- a/src/main/kotlin/net/yested/bootstrap/buttons.kt
+++ b/src/main/kotlin/net/yested/bootstrap/buttons.kt
@@ -1,10 +1,10 @@
 package net.yested.bootstrap
 
-import net.yested.ParentComponent
 import net.yested.HTMLParentComponent
 import net.yested.ButtonType
 import net.yested.Button
 import net.yested.Anchor
+import net.yested.with
 
 public enum class ButtonLook(val code:String) {
     DEFAULT: ButtonLook("default")
@@ -47,13 +47,13 @@ public class BtsButton(type: ButtonType = ButtonType.BUTTON,
 
     {
         setClass()
-        setAttribute("type", type.code)
+        element.setAttribute("type", type.code)
         this.label()
         this.onclick = onclick
     }
 
     fun setClass() {
-        setAttribute("class", "btn btn-${look.code} btn-${size.code} ${if (block) "btn-block" else ""} ${if (buttonActive) "active" else ""}")
+        element.setAttribute("class", "btn btn-${look.code} btn-${size.code} ${if (block) "btn-block" else ""} ${if (buttonActive) "active" else ""}")
     }
 
 }
@@ -65,7 +65,7 @@ public class BtsAnchor(href:String,
 
     {
         this.href = href
-        setAttribute("class", "btn btn-${look.code} btn-${size.code} ${if (block) "btn-block" else ""}")
+        element.setAttribute("class", "btn btn-${look.code} btn-${size.code} ${if (block) "btn-block" else ""}")
     }
 
 }
@@ -76,8 +76,7 @@ public fun HTMLParentComponent.btsButton(type: ButtonType = ButtonType.BUTTON,
                                    size:ButtonSize = ButtonSize.DEFAULT,
                                    block:Boolean = false,
                                    onclick:() -> Unit):Unit {
-    val btn = BtsButton(type = type, label = label, look = look, size = size, block = block, onclick = onclick)
-    this.add(btn)
+    +BtsButton(type = type, label = label, look = look, size = size, block = block, onclick = onclick)
 }
 
 public fun HTMLParentComponent.btsAnchor(href:String,
@@ -85,8 +84,6 @@ public fun HTMLParentComponent.btsAnchor(href:String,
                                   size:ButtonSize = ButtonSize.DEFAULT,
                                   block:Boolean = false,
                                   init:Anchor.() -> Unit):Unit {
-    val btn = BtsAnchor(href = href, look = look, size = size, block = block)
-    btn.init()
-    add(btn)
+    +(BtsAnchor(href = href, look = look, size = size, block = block) with init)
 }
 

--- a/src/main/kotlin/net/yested/bootstrap/buttons.kt
+++ b/src/main/kotlin/net/yested/bootstrap/buttons.kt
@@ -1,10 +1,11 @@
 package net.yested.bootstrap
 
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.ButtonType
 import net.yested.Button
 import net.yested.Anchor
 import net.yested.with
+import net.yested.Attribute
 
 public enum class ButtonLook(val code:String) {
     DEFAULT: ButtonLook("default")
@@ -24,11 +25,11 @@ public enum class ButtonSize(val code:String) {
 }
 
 public class BtsButton(type: ButtonType = ButtonType.BUTTON,
-             label:HTMLParentComponent.()-> Unit,
+             label: HTMLComponent.()-> Unit,
              val look:ButtonLook = ButtonLook.DEFAULT,
              val size:ButtonSize = ButtonSize.DEFAULT,
              val block:Boolean = false,
-             onclick:() -> Unit ) :  HTMLParentComponent("button") {
+             onclick:() -> Unit ) :  HTMLComponent("button") {
 
     private var buttonActive:Boolean = false
 
@@ -61,7 +62,9 @@ public class BtsButton(type: ButtonType = ButtonType.BUTTON,
 public class BtsAnchor(href:String,
                 look:ButtonLook = ButtonLook.DEFAULT,
                 size:ButtonSize = ButtonSize.DEFAULT,
-                block:Boolean = false) :  Anchor() {
+                block:Boolean = false) :  HTMLComponent("a") {
+
+    public var href:String by Attribute();
 
     {
         this.href = href
@@ -70,8 +73,8 @@ public class BtsAnchor(href:String,
 
 }
 
-public fun HTMLParentComponent.btsButton(type: ButtonType = ButtonType.BUTTON,
-                                   label:HTMLParentComponent.()-> Unit,
+public fun HTMLComponent.btsButton(type: ButtonType = ButtonType.BUTTON,
+                                   label: HTMLComponent.()-> Unit,
                                    look:ButtonLook = ButtonLook.DEFAULT,
                                    size:ButtonSize = ButtonSize.DEFAULT,
                                    block:Boolean = false,
@@ -79,11 +82,11 @@ public fun HTMLParentComponent.btsButton(type: ButtonType = ButtonType.BUTTON,
     +BtsButton(type = type, label = label, look = look, size = size, block = block, onclick = onclick)
 }
 
-public fun HTMLParentComponent.btsAnchor(href:String,
+public fun HTMLComponent.btsAnchor(href:String,
                                   look:ButtonLook = ButtonLook.DEFAULT,
                                   size:ButtonSize = ButtonSize.DEFAULT,
                                   block:Boolean = false,
-                                  init:Anchor.() -> Unit):Unit {
-    +(BtsAnchor(href = href, look = look, size = size, block = block) with init)
+                                  init:BtsAnchor.() -> Unit):Unit {
+    +(BtsAnchor(href = href, look = look, size = size, block = block) with  { init() })
 }
 

--- a/src/main/kotlin/net/yested/bootstrap/dialog.kt
+++ b/src/main/kotlin/net/yested/bootstrap/dialog.kt
@@ -1,7 +1,7 @@
 package net.yested.bootstrap
 
 import jquery.JQuery
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.div
 import net.yested.Div
 import net.yested.with
@@ -36,7 +36,7 @@ public class Dialog {
     var body: Div? = null
     var footer: Div? = null
 
-    fun header(init: HTMLParentComponent.() -> Unit) {
+    fun header(init: HTMLComponent.() -> Unit) {
 
         header = div(clazz = "modal-header") {
             tag("button") { clazz = "close"; "type".."button"; "data-dismiss".."modal"
@@ -53,11 +53,11 @@ public class Dialog {
 
     }
 
-    fun body(init: HTMLParentComponent.() -> Unit) {
+    fun body(init: HTMLComponent.() -> Unit) {
         body = div(clazz = "modal-body", init = init)
     }
 
-    fun footer(init: HTMLParentComponent.() -> Unit) {
+    fun footer(init: HTMLComponent.() -> Unit) {
         footer = div(clazz = "modal-footer", init = init)
     }
 

--- a/src/main/kotlin/net/yested/bootstrap/form.kt
+++ b/src/main/kotlin/net/yested/bootstrap/form.kt
@@ -93,7 +93,7 @@ public class Form(private val labelDef:String = "col-sm-2",private val inputDef:
 public fun HTMLParentComponent.btsForm(labelDef:String = "col-sm-2", inputDef:String = "col-sm-10", init:Form.() -> Unit):Unit {
     val form = Form(labelDef = labelDef, inputDef = inputDef)
     form.init()
-    add(form)
+    +form
 }
 
 

--- a/src/main/kotlin/net/yested/bootstrap/form.kt
+++ b/src/main/kotlin/net/yested/bootstrap/form.kt
@@ -28,7 +28,7 @@ package net.yested.bootstrap
         </div>
 </form>
  */
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.Span
 import net.yested.with
 
@@ -64,7 +64,7 @@ public class Validator<T>(val inputElement: InputElement<T>, override val errorT
 
 }
 
-public class Form(private val labelDef:String = "col-sm-2",private val inputDef:String = "col-sm-10") : HTMLParentComponent("form") {
+public class Form(private val labelDef:String = "col-sm-2",private val inputDef:String = "col-sm-10") : HTMLComponent("form") {
 
     {
         element.setAttribute("class", "form-horizontal")
@@ -72,7 +72,7 @@ public class Form(private val labelDef:String = "col-sm-2",private val inputDef:
         element.setAttribute("onsubmit", "return false")
     }
 
-    public fun item(forId:String = "", label:HTMLParentComponent.()->Unit, validator:ValidatorI? = null, content:HTMLParentComponent.()->Unit) {
+    public fun item(forId:String = "", label: HTMLComponent.()->Unit, validator:ValidatorI? = null, content: HTMLComponent.()->Unit) {
 
         val spanErrMsg = Span() with { clazz = "help-block" }
         val divInput = div(clazz = "$inputDef", init = content) with { +spanErrMsg }
@@ -84,13 +84,13 @@ public class Form(private val labelDef:String = "col-sm-2",private val inputDef:
         validator?.onchange {
             isValid ->
                 divFormGroup.clazz = if (isValid) "form-group" else "form-group has-error"
-                spanErrMsg.replace(if (isValid) "" else validator!!.errorText)
+                spanErrMsg.setContent(if (isValid) "" else validator!!.errorText)
         }
     }
 
 }
 
-public fun HTMLParentComponent.btsForm(labelDef:String = "col-sm-2", inputDef:String = "col-sm-10", init:Form.() -> Unit):Unit {
+public fun HTMLComponent.btsForm(labelDef:String = "col-sm-2", inputDef:String = "col-sm-10", init:Form.() -> Unit):Unit {
     val form = Form(labelDef = labelDef, inputDef = inputDef)
     form.init()
     +form

--- a/src/main/kotlin/net/yested/bootstrap/glyphicon.kt
+++ b/src/main/kotlin/net/yested/bootstrap/glyphicon.kt
@@ -2,6 +2,7 @@ package net.yested.bootstrap
 
 import net.yested.Span
 import net.yested.HTMLParentComponent
+import net.yested.with
 
 public class Glyphicon(icon:String) : Span() {
     {
@@ -9,8 +10,6 @@ public class Glyphicon(icon:String) : Span() {
     }
 }
 
-public fun HTMLParentComponent.glyphicon(icon:String): Glyphicon {
-    val glyphicon = Glyphicon(icon = icon)
-    add(glyphicon)
-    return glyphicon
+public fun HTMLParentComponent.glyphicon(icon:String): Unit {
+    +Glyphicon(icon = icon)
 }

--- a/src/main/kotlin/net/yested/bootstrap/glyphicon.kt
+++ b/src/main/kotlin/net/yested/bootstrap/glyphicon.kt
@@ -1,15 +1,21 @@
 package net.yested.bootstrap
 
 import net.yested.Span
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.with
+import net.yested.createElement
+import net.yested.Component
 
-public class Glyphicon(icon:String) : Span() {
+public class Glyphicon(icon:String) : Component {
+
+    override public val element = createElement("span");
+
     {
-        clazz = "glyphicon glyphicon-${icon}"
+        element.className = "glyphicon glyphicon-${icon}"
     }
+
 }
 
-public fun HTMLParentComponent.glyphicon(icon:String): Unit {
+public fun HTMLComponent.glyphicon(icon:String): Unit {
     +Glyphicon(icon = icon)
 }

--- a/src/main/kotlin/net/yested/bootstrap/grid.kt
+++ b/src/main/kotlin/net/yested/bootstrap/grid.kt
@@ -3,26 +3,26 @@
  */
 package net.yested.bootstrap
 
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import java.util.ArrayList
 import net.yested.Span
 import net.yested.with
 import net.yested.Component
-import kotlin.js.dom.html.HTMLElement
 import net.yested.createElement
-import net.yested.add
+import net.yested.appendComponent
 import net.yested.THead
 import net.yested.TBody
+import net.yested.removeChildByName
 
 public data class Column<T>(
-        val label:HTMLParentComponent.() -> Unit,
-        val render:HTMLParentComponent.(T) -> Unit,
+        val label: HTMLComponent.() -> Unit,
+        val render: HTMLComponent.(T) -> Unit,
         val sortFunction:(T, T) -> Int,
         val align:Align = Align.LEFT,
         val defaultSort:Boolean = false,
         val defaultSortOrderAsc:Boolean = true)
 
-public class ColumnHeader<T>(val column:Column<T>, sortFunction:(Column<T>) -> Unit) : Span() {
+public class ColumnHeader<T>(val column:Column<T>, sortFunction:(Column<T>) -> Unit) : HTMLComponent("span") {
 
     var sortOrderAsc:Boolean = column.defaultSortOrderAsc
     var arrowPlaceholder = Span();
@@ -36,14 +36,13 @@ public class ColumnHeader<T>(val column:Column<T>, sortFunction:(Column<T>) -> U
         onclick = {
             sortFunction(column)
         }
-
     }
 
     fun updateSorting(sorteByColumn:Column<T>?, sortAscending:Boolean) {
         if (sorteByColumn != column) {
-            arrowPlaceholder.replace("")
+            arrowPlaceholder.setContent("")
         } else {
-            arrowPlaceholder.replace( glyphicon("arrow-${if (sortAscending) "up" else "down"}"))
+            arrowPlaceholder.setChild(Glyphicon("arrow-${if (sortAscending) "up" else "down"}"))
         }
     }
 
@@ -92,7 +91,7 @@ public class Grid<T>(val columns:Array<Column<T>>) : Component {
     }
 
     private fun renderHeader() {
-        element.add(THead())
+        element.appendComponent(THead() with
              {
                 tr {
                     columnHeaders!!.forEach { columnHeader ->
@@ -102,7 +101,7 @@ public class Grid<T>(val columns:Array<Column<T>>) : Component {
                         }
                     }
                 }
-            }
+            })
     }
 
     private fun sortData(toSort:List<T>):List<T> {
@@ -114,12 +113,12 @@ public class Grid<T>(val columns:Array<Column<T>>) : Component {
     }
 
     private fun displayData() {
-        removeChild("tbody")
+        element.removeChildByName("tbody")
         dataList?.let {
 
             val values = if (sortColumn != null) sortData(dataList!!) else dataList!!
 
-            element.add(TBody())
+            element.appendComponent(TBody() with
                  {
                     values.forEach { item ->
                         tr {
@@ -129,7 +128,7 @@ public class Grid<T>(val columns:Array<Column<T>>) : Component {
                                     column.render(item) } }
                         }
                     }
-                }
+                })
 
         }
     }

--- a/src/main/kotlin/net/yested/bootstrap/grid.kt
+++ b/src/main/kotlin/net/yested/bootstrap/grid.kt
@@ -4,12 +4,15 @@
 package net.yested.bootstrap
 
 import net.yested.HTMLParentComponent
-import net.yested.ParentComponent
-import net.yested.thead
-import net.yested.tbody
 import java.util.ArrayList
 import net.yested.Span
 import net.yested.with
+import net.yested.Component
+import kotlin.js.dom.html.HTMLElement
+import net.yested.createElement
+import net.yested.add
+import net.yested.THead
+import net.yested.TBody
 
 public data class Column<T>(
         val label:HTMLParentComponent.() -> Unit,
@@ -25,7 +28,7 @@ public class ColumnHeader<T>(val column:Column<T>, sortFunction:(Column<T>) -> U
     var arrowPlaceholder = Span();
 
     {
-        setAttribute("style", "cursor: pointer;")
+        element.setAttribute("style", "cursor: pointer;")
 
         column.label()
         +arrowPlaceholder
@@ -46,7 +49,9 @@ public class ColumnHeader<T>(val column:Column<T>, sortFunction:(Column<T>) -> U
 
 }
 
-public class Grid<T>(val columns:Array<Column<T>>) : ParentComponent("table") {
+public class Grid<T>(val columns:Array<Column<T>>) : Component {
+
+    override val element = createElement("table")
 
     private var sortColumn:Column<T>? = null
     private var asc:Boolean = true;
@@ -87,8 +92,8 @@ public class Grid<T>(val columns:Array<Column<T>>) : ParentComponent("table") {
     }
 
     private fun renderHeader() {
-        add(
-            thead {
+        element.add(THead())
+             {
                 tr {
                     columnHeaders!!.forEach { columnHeader ->
                         th {
@@ -98,7 +103,6 @@ public class Grid<T>(val columns:Array<Column<T>>) : ParentComponent("table") {
                     }
                 }
             }
-        )
     }
 
     private fun sortData(toSort:List<T>):List<T> {
@@ -115,8 +119,8 @@ public class Grid<T>(val columns:Array<Column<T>>) : ParentComponent("table") {
 
             val values = if (sortColumn != null) sortData(dataList!!) else dataList!!
 
-            add(
-                tbody {
+            element.add(TBody())
+                 {
                     values.forEach { item ->
                         tr {
                             columns.forEach { column ->
@@ -126,8 +130,6 @@ public class Grid<T>(val columns:Array<Column<T>>) : ParentComponent("table") {
                         }
                     }
                 }
-
-            )
 
         }
     }

--- a/src/main/kotlin/net/yested/bootstrap/inputs.kt
+++ b/src/main/kotlin/net/yested/bootstrap/inputs.kt
@@ -17,6 +17,9 @@ import net.yested.with
 import kotlin.js.dom.html.HTMLSelectElement
 import kotlin.js.dom.html.HTMLOptionElement
 import java.util.HashMap
+import net.yested.Component
+import kotlin.js.dom.html.HTMLElement
+import net.yested.createElement
 
 native trait HTMLInputElementWithOnChange : HTMLInputElement {
     public native var onchange: () -> Unit
@@ -29,7 +32,9 @@ public trait InputElement<T> {
     fun decorate(valid:Boolean)
 }
 
-public class TextInput(placeholder:String? = null) : ParentComponent("input"), InputElement<String> {
+public class TextInput(placeholder:String? = null) : Component, InputElement<String> {
+
+    override val element: HTMLElement = createElement("input")
 
     private val onChangeListeners: ArrayList<Function0<Unit>> = ArrayList();
     private val onChangeLiveListeners: ArrayList<Function0<Unit>> = ArrayList();

--- a/src/main/kotlin/net/yested/bootstrap/layout.kt
+++ b/src/main/kotlin/net/yested/bootstrap/layout.kt
@@ -1,21 +1,25 @@
 package net.yested.bootstrap
 
 import net.yested.Div
-import net.yested.ParentComponent
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.with
 import net.yested.div
 import kotlin.js.dom.html.HTMLElement
 import net.yested.el
+import net.yested.Component
+import net.yested.createElement
+import net.yested.appendComponent
 
-public class Row() : ParentComponent("div") {
+public class Row(): Component {
+
+    override val element = createElement("div");
 
     {
-        setAttribute("class", "row")
+        element.setAttribute("class", "row")
     }
 
-    public fun col(vararg modifiers: ColumnModifier, init:HTMLParentComponent.() -> Unit) {
-        add(
+    public fun col(vararg modifiers: ColumnModifier, init: HTMLComponent.() -> Unit) {
+        element.appendComponent(
             Div() with {
                 clazz = modifiers map {it.toString()} join(" ")
                 init()
@@ -27,10 +31,10 @@ public class Row() : ParentComponent("div") {
 public class Page(val element: HTMLElement) {
 
     public fun topMenu(navbar: Navbar) {
-        element.appendChild(navbar.element)
+        element.appendComponent(navbar)
     }
 
-    public fun content(init: HTMLParentComponent.() -> Unit): Unit {
+    public fun content(init: HTMLComponent.() -> Unit): Unit {
         element.appendChild(
                 div {
                     "class".."container theme-showcase"
@@ -39,7 +43,7 @@ public class Page(val element: HTMLElement) {
                 }.element)
     }
 
-    public fun footer(init:HTMLParentComponent.() -> Unit): Unit {
+    public fun footer(init: HTMLComponent.() -> Unit): Unit {
         element.appendChild(
                 div {
                     div(clazz = "container") {
@@ -51,23 +55,18 @@ public class Page(val element: HTMLElement) {
 
 }
 
-public class PageHeader  : HTMLParentComponent("div") {
+public class PageHeader  : HTMLComponent("div") {
     {
         clazz = "page-header"
     }
 }
 
-public fun HTMLParentComponent.pageHeader(init: HTMLParentComponent.() -> Unit) {
-    val pageHeader = PageHeader()
-    pageHeader.init()
-    add(pageHeader)
+public fun HTMLComponent.pageHeader(init: HTMLComponent.() -> Unit) {
+    +(PageHeader() with  { init() })
 }
 
-public fun HTMLParentComponent.row(init:Row.()->Unit): Row {
-    val row = Row()
-    row.init()
-    add(row)
-    return row
+public fun HTMLComponent.row(init:Row.()->Unit) {
+    +(Row() with  { init() })
 }
 
 public fun page(placeholderElementId:String, init:Page.() -> Unit):Unit {

--- a/src/main/kotlin/net/yested/bootstrap/navbar.kt
+++ b/src/main/kotlin/net/yested/bootstrap/navbar.kt
@@ -1,9 +1,7 @@
 package net.yested.bootstrap
 
-import net.yested.ParentComponent
 import net.yested.div
-import net.yested.HTMLParentComponent
-import net.yested.tag
+import net.yested.HTMLComponent
 import net.yested.UL
 import net.yested.Li
 import net.yested.Anchor
@@ -11,6 +9,9 @@ import java.util.ArrayList
 import net.yested.with
 import net.yested.Div
 import net.yested.Span
+import net.yested.createElement
+import net.yested.Component
+import net.yested.appendComponent
 
 /**
  * Created by jean on 24.11.2014.
@@ -61,23 +62,25 @@ public enum class NavbarLook(val code:String) {
     INVERSE : NavbarLook("inverse")
 }
 
-public class Navbar(id:String, position: NavbarPosition? = null, look:NavbarLook = NavbarLook.DEFAULT) : ParentComponent("nav") {
+public class Navbar(id:String, position: NavbarPosition? = null, look:NavbarLook = NavbarLook.DEFAULT) : Component {
+
+    override public var element = createElement("nav")
 
     private val ul = UL() with { clazz = "nav navbar-nav" }
     private val collapsible = div(id = id, clazz = "navbar-collapse collapse") { +ul }
 
-    private val menuItems = ArrayList<Li>();
+    private val menuItems = ArrayList<HTMLComponent>();
     private val brandLink = Anchor();
 
     {
 
-        setAttribute("class", "navbar navbar-${look.code} ${if (position != null) "navbar-${position.code}" else ""}")
-        setAttribute("role", "navigation")
+        element.setAttribute("class", "navbar navbar-${look.code} ${if (position != null) "navbar-${position.code}" else ""}")
+        element.setAttribute("role", "navigation")
 
-        add(
+        element.appendComponent(
             div(clazz = "container") {
                 div(clazz = "navbar-header") {
-                    + tag("button") {
+                    +(HTMLComponent("button") with {
                         "type".."button"; "class".."navbar-toggle collapsed";
                         "data-toggle".."collapse"; "data-target".."#${id}"
                         "aria-expanded".."false"; "aria-controls".."navbar"
@@ -85,7 +88,7 @@ public class Navbar(id:String, position: NavbarPosition? = null, look:NavbarLook
                         span(clazz = "icon-bar") { }
                         span(clazz = "icon-bar") { }
                         span(clazz = "icon-bar") { }
-                    }
+                    })
                     +brandLink
                 }
                 +collapsible
@@ -94,10 +97,10 @@ public class Navbar(id:String, position: NavbarPosition? = null, look:NavbarLook
 
     }
 
-    public fun brand(href:String = "/", init: HTMLParentComponent.() -> Unit):Unit {
+    public fun brand(href:String = "/", init: HTMLComponent.() -> Unit):Unit {
         brandLink.href = href
         brandLink.clazz = "navbar-brand"
-        brandLink.replace( Span() with { init() })
+        brandLink.setChild( Span() with { init() })
         brandLink.onclick = {
             deselectAll()
         }
@@ -120,13 +123,13 @@ public class Navbar(id:String, position: NavbarPosition? = null, look:NavbarLook
         li with {
             a(href = href, onclick = ::linkClicked, init = init)
         }
-        ul.add(li)
+        ul.appendChild(li)
         menuItems.add(li)
     }
 
     public fun dropdown(label: Anchor.()->Unit, init:NavBarDropdown.()->Unit):Unit {
         val dropdown = NavBarDropdown({ deselectAll() }, label) with { init() }
-        ul.add(dropdown)
+        ul.appendChild(dropdown)
         menuItems.add(dropdown)
     }
 
@@ -135,16 +138,16 @@ public class Navbar(id:String, position: NavbarPosition? = null, look:NavbarLook
     }
 
     public fun left(init : Div.()->Unit) {
-        collapsible.add(div(clazz = "navbar-left") { init() })
+        collapsible.appendChild(div(clazz = "navbar-left") { init() })
     }
 
     public fun right(init : Div.()->Unit) {
-        collapsible.add(div(clazz = "navbar-right") { init() })
+        collapsible.appendChild(div(clazz = "navbar-right") { init() })
     }
 
 }
 
-class NavBarDropdown(private val deselectFun:() -> Unit, label: Anchor.()->Unit) : Li() {
+class NavBarDropdown(private val deselectFun:() -> Unit, label: Anchor.()->Unit) : HTMLComponent("li") {
 
     private val ul = UL() with {
         "class".."dropdown-menu"
@@ -152,8 +155,8 @@ class NavBarDropdown(private val deselectFun:() -> Unit, label: Anchor.()->Unit)
     }
 
     {
-        setAttribute("class", "dropdown")
-        add(
+        element.setAttribute("class", "dropdown")
+        element.appendComponent(
                 Anchor() with {
                     "class".."dropdown-toggle"
                     "data-toggle".."dropdown"
@@ -163,27 +166,27 @@ class NavBarDropdown(private val deselectFun:() -> Unit, label: Anchor.()->Unit)
                     label()
                     span(clazz = "caret") { }
                 })
-        add(ul)
+        element.appendComponent(ul)
     }
 
     fun selectThis() {
         deselectFun();
-        setAttribute("class", "dropdown active");
+        element.setAttribute("class", "dropdown active");
     }
 
     public fun item(href:String = "#", onclick: Function0<Unit>? = null, init: Anchor.() -> Unit) {
         val li = Li() with {
             a(href = href, onclick = { selectThis(); onclick?.let { onclick() } }, init = init)
         }
-        ul.add(li)
+        ul.appendChild(li)
     }
 
     public fun divider() {
-        ul.add(tag("li", { "class".."divider" }))
+        ul.appendChild(HTMLComponent("li") with { "class".."divider" })
     }
 
 }
 
-public fun HTMLParentComponent.navbar(id:String, position: NavbarPosition? = null, look:NavbarLook = NavbarLook.DEFAULT, init: Navbar.() -> Unit):Unit {
-    add(Navbar(id = id, position = position, look = look) with { init() })
+public fun HTMLComponent.navbar(id:String, position: NavbarPosition? = null, look:NavbarLook = NavbarLook.DEFAULT, init: Navbar.() -> Unit):Unit {
+    +(Navbar(id = id, position = position, look = look) with { init() })
 }

--- a/src/main/kotlin/net/yested/bootstrap/pagination.kt
+++ b/src/main/kotlin/net/yested/bootstrap/pagination.kt
@@ -1,10 +1,13 @@
 package net.yested.bootstrap
 
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.UL
 import net.yested.with
 import net.yested.Li
 import java.util.ArrayList
+import net.yested.createElement
+import net.yested.Component
+import net.yested.appendComponent
 
 /**
  * <nav>
@@ -15,7 +18,9 @@ import java.util.ArrayList
 </ul>
 </nav>
  */
-public class Pagination(val count:Int, val defaultSelection:Int = 1, val listener:(Int) -> Unit) : HTMLParentComponent("nav") {
+public class Pagination(val count:Int, val defaultSelection:Int = 1, val listener:(Int) -> Unit) : Component {
+
+    override public val element = createElement("nav")
 
     private var selectedItem:Int = defaultSelection
 
@@ -31,15 +36,15 @@ public class Pagination(val count:Int, val defaultSelection:Int = 1, val listene
         }
 
     {
-        add(list)
+        element.appendComponent(list)
         replaceItems()
         redisplay(selectedItem)
     }
 
     private fun replaceItems() {
         items = generateItems()
-        list.replace("")
-        items.forEach { list.add(it) }
+        list.setContent("")
+        items.forEach { list.appendChild(it) }
     }
 
     private fun generateItems(): List<Li> {
@@ -87,5 +92,5 @@ public class Pagination(val count:Int, val defaultSelection:Int = 1, val listene
 
 }
 
-public fun HTMLParentComponent.pagination(count:Int, defaultSelection:Int = 1, listener:(Int) -> Unit): Unit =
-    add( net.yested.bootstrap.Pagination(count,defaultSelection, listener) )
+public fun HTMLComponent.pagination(count:Int, defaultSelection:Int = 1, listener:(Int) -> Unit): Unit =
+    +( Pagination(count,defaultSelection, listener) )

--- a/src/main/kotlin/net/yested/bootstrap/panels.kt
+++ b/src/main/kotlin/net/yested/bootstrap/panels.kt
@@ -1,10 +1,11 @@
 package net.yested.bootstrap
 
-import net.yested.ParentComponent
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.Div
 import net.yested.with
-import net.yested.bootstrap.ButtonSize
+import net.yested.Component
+import net.yested.createElement
+import net.yested.appendComponent
 
 public enum class PanelStyle(val code:String) {
     DEFAULT : PanelStyle("default")
@@ -15,35 +16,35 @@ public enum class PanelStyle(val code:String) {
     DANGER : PanelStyle("danger")
 }
 
-public class Panel(style : PanelStyle = PanelStyle.DEFAULT) : ParentComponent("div") {
+public class Panel(style : PanelStyle = PanelStyle.DEFAULT) : Component {
+
+    override public val element = createElement("div")
 
     private val heading = Div() with { clazz = "panel-heading" }
     private val body = Div() with { clazz = "panel-body" }
     private val footer = Div() with { clazz = "panel-footer" }
 
     {
-        setAttribute("class", "panel panel-${style.code}")
-        add(heading)
-        add(body)
+        element.setAttribute("class", "panel panel-${style.code}")
+        element.appendComponent(heading)
+        element.appendComponent(body)
     }
 
-    public fun heading(init: HTMLParentComponent.() -> Unit) {
+    public fun heading(init: HTMLComponent.() -> Unit) {
         heading.init()
     }
 
-    public fun content(init: HTMLParentComponent.() -> Unit) {
+    public fun content(init: HTMLComponent.() -> Unit) {
         body.init()
     }
 
-    public fun footer(init: HTMLParentComponent.() -> Unit) {
+    public fun footer(init: HTMLComponent.() -> Unit) {
         footer.init()
-        add(footer)
+        element.appendComponent(footer)
     }
 
 }
 
-public fun HTMLParentComponent.panel(style:PanelStyle = PanelStyle.DEFAULT, init:Panel.() -> Unit) {
-    val panel = Panel(style = style)
-    panel.init()
-    add(panel)
+public fun HTMLComponent.panel(style:PanelStyle = PanelStyle.DEFAULT, init:Panel.() -> Unit) {
+    + (Panel(style = style) with  { init() })
 }

--- a/src/main/kotlin/net/yested/bootstrap/tabs.kt
+++ b/src/main/kotlin/net/yested/bootstrap/tabs.kt
@@ -3,16 +3,16 @@
  */
 package net.yested.bootstrap
 
-import net.yested.ParentComponent
 import net.yested.UL
 import net.yested.Div
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.Li
 import net.yested.Anchor
 import net.yested.with
 import java.util.HashMap
-import java.util.ArrayList
-import net.yested.div
+import net.yested.Component
+import net.yested.createElement
+import net.yested.appendComponent
 
 /**
  * <div role="tabpanel">
@@ -29,13 +29,15 @@ import net.yested.div
     </div>
 </div>
  */
-public class Tabs : ParentComponent("div") {
+public class Tabs : Component {
+
+    public override val element = createElement("div")
 
     private val bar = UL() with { role = "tablist"; clazz = "nav nav-tabs"}
 
     private val content = Div() with { clazz = "tab-content"}
 
-    private val anchorsLi = java.util.ArrayList<HTMLParentComponent>();
+    private val anchorsLi = java.util.ArrayList<HTMLComponent>();
 
     private val tabsRendered = HashMap<Int, Div>()
 
@@ -44,12 +46,12 @@ public class Tabs : ParentComponent("div") {
     {
         element.setAttribute("role", "tabpanel")
 
-        add(bar)
-        add(content)
+        element.appendComponent(bar)
+        element.appendComponent(content)
 
     }
 
-    private fun renderContent(tabId:Int, init:HTMLParentComponent.()->Unit):Div =
+    private fun renderContent(tabId:Int, init: HTMLComponent.()->Unit):Div =
         if (tabsRendered.containsKey(tabId)) {
             tabsRendered.get(tabId)!!
         } else {
@@ -61,7 +63,7 @@ public class Tabs : ParentComponent("div") {
             div
         }
 
-    private fun activateTab(li:Li, tabId:Int, onSelect:Function0<Unit>?, init:HTMLParentComponent.()->Unit) {
+    private fun activateTab(li:Li, tabId:Int, onSelect:Function0<Unit>?, init: HTMLComponent.()->Unit) {
 
         li.clazz = "active"
 
@@ -74,7 +76,7 @@ public class Tabs : ParentComponent("div") {
         }
     }
 
-    public fun tab(active:Boolean = false, header:HTMLParentComponent.()->Unit, onSelect:Function0<Unit>? = null, init:HTMLParentComponent.()->Unit) {
+    public fun tab(active:Boolean = false, header: HTMLComponent.()->Unit, onSelect:Function0<Unit>? = null, init: HTMLComponent.()->Unit) {
 
         val tabId = index++;
 
@@ -84,13 +86,14 @@ public class Tabs : ParentComponent("div") {
             header()
         }
 
-        val li = bar.li { +a; role = "presentation" }
+        val li = Li() with { +a; role = "presentation" }
+        bar.appendChild(li)
 
         a.onclick = {
             activateTab(li, tabId, onSelect, init)
         }
 
-        bar.add(li)
+        //bar.add(li)
         anchorsLi.add(li)
 
         if (active) {
@@ -101,8 +104,6 @@ public class Tabs : ParentComponent("div") {
 
 }
 
-public fun HTMLParentComponent.tabs(init:Tabs.() -> Unit): Unit {
-    val tabs = Tabs()
-    tabs.init()
-    add(tabs)
+public fun HTMLComponent.tabs(init:Tabs.() -> Unit): Unit {
+    +(Tabs() with  { init() })
 }

--- a/src/main/kotlin/net/yested/bootstrap/typography.kt
+++ b/src/main/kotlin/net/yested/bootstrap/typography.kt
@@ -1,6 +1,6 @@
 package net.yested.bootstrap
 
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 import net.yested.Span
 import net.yested.with
 import net.yested.P
@@ -13,25 +13,25 @@ public enum class TextAlign(val code:String) {
     NOWRAP : TextAlign("nowrap")
 }
 
-public fun HTMLParentComponent.aligned(align:TextAlign, init:P.() -> Unit) {
-    add(P() with {
+public fun HTMLComponent.aligned(align:TextAlign, init:P.() -> Unit) {
+    +(P() with {
         clazz = "text-${align.code}"
         init()
     })
 }
 
-private fun addSpan(parent:HTMLParentComponent, clazz:String, init:Span.() -> Unit) {
-    parent.add(Span() with {
+private fun addSpan(parent: HTMLComponent, clazz:String, init:Span.() -> Unit) {
+    parent.appendChild(Span() with {
         this.clazz = clazz
         init()
     })
 }
 
-public fun HTMLParentComponent.uppercase(init:Span.() -> Unit):Unit =
-    addSpan(this, "text-uppercase", init)
+public fun HTMLComponent.uppercase(init:Span.() -> Unit):Unit =
+        addSpan(this, "text-uppercase", init)
 
-public fun HTMLParentComponent.lowercase(init:Span.() -> Unit):Unit =
+public fun HTMLComponent.lowercase(init:Span.() -> Unit):Unit =
         addSpan(this, "text-lowercase", init)
 
-public fun HTMLParentComponent.capitalize(init:Span.() -> Unit):Unit =
+public fun HTMLComponent.capitalize(init:Span.() -> Unit):Unit =
         addSpan(this, "text-capitalize", init)

--- a/src/main/kotlin/net/yested/formatting.kt
+++ b/src/main/kotlin/net/yested/formatting.kt
@@ -8,7 +8,7 @@ public data class Color(
 
 public fun Color.toHTMLColor(): String = "rgba(${this.red},${this.green},${this.blue},${this.alpha})"
 
-public class Colorized(color:Color? = null, backgroundColor: Color? = null, init: HTMLParentComponent.() -> Unit) : Span() {
+public class Colorized(color:Color? = null, backgroundColor: Color? = null, init: HTMLComponent.() -> Unit) : HTMLComponent("span") {
 
     {
         style = (if (color != null) "color: ${color.toHTMLColor()};" else "") +

--- a/src/main/kotlin/net/yested/spin/spinner.kt
+++ b/src/main/kotlin/net/yested/spin/spinner.kt
@@ -5,7 +5,7 @@ import kotlin.js.dom.html.HTMLElement
 import net.yested.ChartItem
 import net.yested.LineData
 import net.yested.Context
-import net.yested.HTMLParentComponent
+import net.yested.HTMLComponent
 
 public native class SpinnerNative() {
     public fun spin(): SpinnerCreated = noImpl
@@ -64,6 +64,6 @@ public class Spinner(val options:SpinnerOptions = SpinnerOptions()) : Component 
 
 }
 
-public fun HTMLParentComponent.spinner(options:SpinnerOptions = SpinnerOptions()) {
-    add(Spinner(options))
+public fun HTMLComponent.spinner(options:SpinnerOptions = SpinnerOptions()) {
+    +(Spinner(options))
 }


### PR DESCRIPTION
Remove ParentComponent
- appendChild, appendContent etc moved to HTMLComponent (original HTMLParentComponent)

Component trait should be kept simple:
```
public trait Component {
    val element : HTMLElement
}
```
So that if you somebody create non-DSL component like Breadcrumb or Grid, user of the component cannot call some unexpected methods of the component.

All components implementation must provide element value:
```
public class Tabs : Component {
    public override val element = createElement("div")
```
if user wants to manipulate with element, he must do it directly:
element.appendChild(...)
element.setAttribute(..)

Also removing some inconsistencies, some components now extend Component instead of HTMLParentComponent. 

method rename:
replace -> setContent, setChild
