### PR TITLE
HTML input elements refactoring

### DIFF
--- a/src/main/docsite/ajax/ajax_get.kt
+++ b/src/main/docsite/ajax/ajax_get.kt
@@ -21,6 +21,7 @@ import net.yested.bootstrap.Medium
 import net.yested.Fade
 import net.yested.bootstrap.InputField
 import net.yested.bootstrap.FormStyle
+import net.yested.bootstrap.StringInputField
 
 /**
  * Created by jean on 24.12.2014.
@@ -79,7 +80,7 @@ native trait WeatherData {
 
 fun createAjaxGetSection(): Div {
 
-    val textInput = InputField(placeholder = "Type city name and press Enter")
+    val textInput = StringInputField(placeholder = "Type city name and press Enter")
     val validator = Validator(inputElement = textInput, errorText = "Enter at least 3 characters", validator = { it.length() > 2})
     val temperatureSpan = Div()
 

--- a/src/main/docsite/bootstrap/checkbox.kt
+++ b/src/main/docsite/bootstrap/checkbox.kt
@@ -21,7 +21,7 @@ fun createCheckboxSection(id:String): Div {
     val checkbox = BtsCheckBox() { +"Select me" }
 
     fun checkboxClicked() {
-        placeholder.setContent("Is checkbox checked: ${if (checkbox.value) "Yes" else "No"}")
+        placeholder.setContent("Is checkbox checked: ${if (checkbox.checked) "Yes" else "No"}")
     }
 
     checkbox.addOnChangeListener { checkboxClicked() }
@@ -51,7 +51,7 @@ fun createCheckboxSection(id:String): Div {
 val checkbox = BtsCheckBox() { +"Select me" }
 
 fun checkboxClicked() {
-    placeholder.setContent("Is checkbox checked: ${if (checkbox.value) "Yes" else "No"}")
+    placeholder.setContent("Is checkbox checked: ${if (checkbox.checked) "Yes" else "No"}")
 }
 
 checkbox.addOnChangeListener { checkboxClicked() }

--- a/src/main/docsite/bootstrap/dialogs.kt
+++ b/src/main/docsite/bootstrap/dialogs.kt
@@ -10,9 +10,9 @@ import net.yested.bootstrap.ButtonLook
 import net.yested.with
 import net.yested.bootstrap.btsForm
 import net.yested.bootstrap.btsButton
-import net.yested.bootstrap.inputField
 import net.yested.bootstrap.Medium
 import net.yested.bootstrap.DialogSize
+import net.yested.bootstrap.StringInputField
 
 fun createDialogs(id: String): Div {
 
@@ -23,7 +23,9 @@ fun createDialogs(id: String): Div {
         body {
             btsForm {
                 item(forId = "nameId", label = { + "Name" }) {
-                    inputField(placeholder = "Name") { this.id = "nameId"}
+                    +(StringInputField(placeholder = "Name") with {
+                        this.id = "nameId"
+                    })
                 }
             }
         }

--- a/src/main/docsite/bootstrap/floatingpanelcontainer.kt
+++ b/src/main/docsite/bootstrap/floatingpanelcontainer.kt
@@ -20,6 +20,7 @@ import net.yested.TextArea
 import net.yested.bootstrap.FloatingPanelContainer
 import net.yested.bootstrap.InputField
 import net.yested.bootstrap.IntInputField
+import net.yested.bootstrap.StringInputField
 
 /**
  * Created by jean on 1.2.2015.
@@ -47,7 +48,7 @@ fun createFloatingPanelContainerSection(id: String): Div {
     addPanel("400px", PanelStyle.INFO)
 
     val looks = PanelStyle.values().toList()
-    val inputField = IntInputField(placeholder = "Size in Px") with { data = 150 }
+    val inputField = StringInputField(placeholder = "Size in Px") with { data = "150px" }
     val selectLook = Select(options = looks) { it.name() }
 
     return div(id = id) {

--- a/src/main/docsite/bootstrap/floatingpanelcontainer.kt
+++ b/src/main/docsite/bootstrap/floatingpanelcontainer.kt
@@ -19,6 +19,7 @@ import net.yested.bootstrap.AlertStyle
 import net.yested.TextArea
 import net.yested.bootstrap.FloatingPanelContainer
 import net.yested.bootstrap.InputField
+import net.yested.bootstrap.IntInputField
 
 /**
  * Created by jean on 1.2.2015.
@@ -31,7 +32,7 @@ fun createFloatingPanelContainerSection(id: String): Div {
 
     fun addPanel(size:String, panelStyle: PanelStyle) {
 
-        val textArea = TextArea(2) with  { value = "Resize me!" }
+        val textArea = TextArea(2) with  { data = "Resize me!" }
         val panel = Panel(style = panelStyle, dismissible = true) with {
             heading { +"Some panel ${counter++} (${size})" }
             content { +textArea }
@@ -46,8 +47,8 @@ fun createFloatingPanelContainerSection(id: String): Div {
     addPanel("400px", PanelStyle.INFO)
 
     val looks = PanelStyle.values().toList()
-    val inputField = InputField(placeholder = "Size in Px") with { value = "150px" }
-    val selectLook = Select(data = looks) { it.name() }
+    val inputField = IntInputField(placeholder = "Size in Px") with { data = 150 }
+    val selectLook = Select(options = looks) { it.name() }
 
     return div(id = id) {
         row {

--- a/src/main/docsite/bootstrap/forms.kt
+++ b/src/main/docsite/bootstrap/forms.kt
@@ -2,7 +2,6 @@ package bootstrap
 
 import net.yested.div
 import net.yested.Div
-import net.yested.bootstrap.inputField
 import net.yested.bootstrap.row
 import net.yested.bootstrap.pageHeader
 import net.yested.bootstrap.btsForm
@@ -10,6 +9,7 @@ import net.yested.bootstrap.inputAddOn
 import net.yested.bootstrap.Medium
 import net.yested.bootstrap.FormStyle
 import net.yested.bootstrap.InputField
+import net.yested.bootstrap.StringInputField
 
 fun createForm(id: String): Div {
 
@@ -30,10 +30,10 @@ of label and input for Horizontal layout."""
                 h4 { +"Demo" }
                 btsForm(formStyle = FormStyle.DEFAULT) {
                     item(label = { +"Username" }) {
-                        inputField(placeholder = "Enter your username") { }
+                        +StringInputField(placeholder = "Enter your username")
                     }
                     item(label = { +"Salary" }) {
-                        inputAddOn(prefix = "$", suffix = ".00", textInput = InputField(placeholder = "Salary") )
+                        inputAddOn(prefix = "$", suffix = ".00", textInput = StringInputField(placeholder = "Salary") )
                     }
                 }
             }

--- a/src/main/docsite/bootstrap/inputs.kt
+++ b/src/main/docsite/bootstrap/inputs.kt
@@ -14,10 +14,11 @@ import net.yested.bootstrap.BtsButton
 import net.yested.bootstrap.Medium
 import net.yested.with
 import net.yested.bootstrap.InputField
+import net.yested.bootstrap.StringInputField
 
 fun createInputs(id: String): Div {
 
-    val textInput = InputField(placeholder = "Mandatory field")
+    val textInput = StringInputField(placeholder = "Mandatory field")
 
     val validator = Validator(textInput, errorText = "At least 3 chars!!") { value -> value.size > 2 }
 
@@ -54,10 +55,10 @@ Please note that validator is also attached to form item.
                         +button
                     }
                     item(label = { +"Disabled input" }) {
-                        +(InputField() with { value = "Some value"; disabled = true })
+                        +(StringInputField() with { data = "Some value"; disabled = true })
                     }
                     item(label = { +"Readonly input" }) {
-                        +(InputField() with { value = "Some value"; readonly = true })
+                        +(StringInputField() with { data = "Some value"; readOnly = true })
                     }
                 }
             }

--- a/src/main/docsite/bootstrap/navbar.kt
+++ b/src/main/docsite/bootstrap/navbar.kt
@@ -7,10 +7,10 @@ import net.yested.bootstrap.pageHeader
 import net.yested.Div
 import net.yested.bootstrap.navbar
 import net.yested.bootstrap.glyphicon
-import net.yested.bootstrap.inputField
 import net.yested.bootstrap.btsButton
 import net.yested.ButtonType
 import net.yested.bootstrap.NavbarLook
+import net.yested.bootstrap.StringInputField
 
 fun createNavbarSection(id: String): Div {
 
@@ -87,7 +87,7 @@ fun createNavbarSection(id: String): Div {
                     left {
                         form { "class".."navbar-form"
                             div(clazz = "form-group") {
-                                inputField(placeholder = "username") {}
+                                +StringInputField(placeholder = "username")
                             }
                             btsButton(type = ButtonType.SUBMIT, label = { +"Login"}) {}
                         }

--- a/src/main/docsite/bootstrap/rowpanelcontainer.kt
+++ b/src/main/docsite/bootstrap/rowpanelcontainer.kt
@@ -31,7 +31,7 @@ fun createRowPanelContainerSection(id: String): Div {
 
     fun addPanel(size:DeviceSize, panelStyle: PanelStyle) {
 
-        val textArea = TextArea(2) with  { value = "Resize me!" }
+        val textArea = TextArea(2) with  { data = "Resize me!" }
         val panel = Panel(style = panelStyle, dismissible = true) with {
             heading { +"A panel ${counter++} (${size})" }
             content { +textArea }
@@ -46,10 +46,10 @@ fun createRowPanelContainerSection(id: String): Div {
     addPanel(Medium(4), PanelStyle.INFO)
 
     val sizes = arrayListOf(Medium(4), Medium(6), Medium(8))
-    val selectSize = Select<DeviceSize>(data = sizes) { "${it.size}" }
+    val selectSize = Select<DeviceSize>(options = sizes) { "${it.size}" }
 
     val looks = PanelStyle.values().toList()
-    val selectLook = Select(data = looks) { it.name() }
+    val selectLook = Select(options = looks) { it.name() }
 
     return div(id = id) {
         row {

--- a/src/main/docsite/bootstrap/select.kt
+++ b/src/main/docsite/bootstrap/select.kt
@@ -26,13 +26,13 @@ fun createSelectSection(id: String): Div {
             Car("Citroen", "Purple"))
 
     val resultSingleSelect = Div()
-    val singleSelect = Select(data = someData, renderer = { "${it.model} (${it.color})" })
+    val singleSelect = Select(options = someData, renderer = { "${it.model} (${it.color})" })
     singleSelect.addOnChangeListener {
         resultSingleSelect.setContent( "Selected: ${singleSelect.selectedItems.first().model}")
     }
 
     val resultMultiSelect = Div()
-    val multiSelect = Select(data = someData, multiple = true, size = 4, renderer = { "${it.model} (${it.color})" })
+    val multiSelect = Select(options = someData, multiple = true, size = 4, renderer = { "${it.model} (${it.color})" })
     multiSelect.addOnChangeListener {
         resultMultiSelect.setContent( "Selected: " + multiSelect.selectedItems.map { "${it.model}" }.join(" and "))
     }

--- a/src/main/docsite/bootstrap/tabs.kt
+++ b/src/main/docsite/bootstrap/tabs.kt
@@ -2,7 +2,6 @@ package bootstrap
 
 import net.yested.div
 import net.yested.Div
-import net.yested.bootstrap.inputField
 import net.yested.bootstrap.tabs
 import net.yested.text
 import net.yested.bootstrap.row
@@ -15,6 +14,7 @@ import net.yested.bootstrap.ButtonSize
 import net.yested.bootstrap.BtsCheckBox
 import net.yested.bootstrap.btsForm
 import net.yested.bootstrap.FormStyle
+import net.yested.bootstrap.StringInputField
 
 /**
  * Created by jean on 20.12.2014.
@@ -23,12 +23,12 @@ fun createTabs(id: String): Div {
 
     var tabIndex = 3
 
-    val dismissibleCheckbox = BtsCheckBox(label = {+"Dismissible" }) with { value = true }
+    val dismissibleCheckbox = BtsCheckBox(label = {+"Dismissible" }) with { data = true }
 
     val tabs = Tabs(canChangeOrder = true) with {
         tab(dismissible = true, header = text("First")) {
             div {
-                inputField(placeholder = "Placeholder 1") { }
+                +StringInputField(placeholder = "Placeholder 1")
             }
         }
         tab(dismissible = true, header = text("Second")) {
@@ -42,7 +42,7 @@ fun createTabs(id: String): Div {
     }
 
     fun addTab(tabIndex:Int) {
-        val tabId = tabs.tab(dismissible = dismissibleCheckbox.value, header = { +"Tab${tabIndex}" }) {
+        val tabId = tabs.tab(dismissible = dismissibleCheckbox.data, header = { +"Tab${tabIndex}" }) {
             div {
                 +"Content of tab: ${tabIndex}"
             }

--- a/src/main/docsite/complex/masterdetails.kt
+++ b/src/main/docsite/complex/masterdetails.kt
@@ -24,6 +24,7 @@ import kotlin.js.dom.html.HTMLElement
 import java.util.ArrayList
 import net.yested.bootstrap.InputField
 import net.yested.compareByValue
+import net.yested.bootstrap.StringInputField
 
 enum class Continent(val label:String) {
     EUROPE : Continent("Europe");
@@ -39,9 +40,9 @@ class DetailScreen(
         val saveHandler:(City)->Unit,
         val cancelHandler:()->Unit) : Component {
 
-    val textInput = InputField(placeholder = "City name")
+    val textInput = StringInputField(placeholder = "City name")
     val validator = Validator(inputElement = textInput, errorText = "Name is mandatory", validator = { it.size > 3})
-    val select = Select(data = Continent.values().toList(), renderer = { it.label })
+    val select = Select(options = Continent.values().toList(), renderer = { it.label })
 
     fun save() {
         if (validator.isValid()) {

--- a/src/main/docsite/complex/spinner.kt
+++ b/src/main/docsite/complex/spinner.kt
@@ -2,7 +2,6 @@ package complex
 
 import net.yested.div
 import net.yested.Div
-import net.yested.bootstrap.inputField
 import net.yested.bootstrap.tabs
 import net.yested.text
 import net.yested.bootstrap.row

--- a/src/main/docsite/html/elementEvents.kt
+++ b/src/main/docsite/html/elementEvents.kt
@@ -18,7 +18,7 @@ fun elementEventsSection(): Div {
     val capturedEvents = TextArea(rows = 8) with { clazz = "form-control" }
 
     fun addMessage(eventName:String) {
-        capturedEvents.value += "${index++} - ${eventName}\n"
+        capturedEvents.data += "${index++} - ${eventName}\n"
         capturedEvents.scrollDown()
     }
 
@@ -42,7 +42,7 @@ fun elementEventsSection(): Div {
                 div {
                     textArea(rows = 3) {
                         clazz = "form-control"
-                        value = "Play with this TextArea to see all the events dispatched."
+                        data = "Play with this TextArea to see all the events dispatched."
                         onmouseover = { addMessage("onmouseover") }
                         onmouseout = { addMessage("onmouseout") }
                         onclick = { addMessage("onclick") }

--- a/src/main/docsite/html/htmlComponents.kt
+++ b/src/main/docsite/html/htmlComponents.kt
@@ -80,7 +80,7 @@ fun htmlSection(): Div {
                     h3 { +"H3" }
                     h4 { +"H4" }
                     h5 { +"H5" }
-                    checkbox { onchange = { println("changed to: ${this.checked}")} }
+                    checkbox { addOnChangeListener { println("changed to: ${this.checked}")} }
                     br()
                     button(label = { +"Press me" },
                             type = ButtonType.BUTTON,

--- a/src/main/kotlin/net/yested/ajax.kt
+++ b/src/main/kotlin/net/yested/ajax.kt
@@ -6,7 +6,7 @@ data class AjaxRequest<RESULT>(val url:String, val type:String = "POST", val dat
 
 native
 trait JQAjax {
-    fun <T> get(url:String, loaded:(response: T?) -> Unit) : Unit = noImpl
+    fun <T> get(url:String, loaded:(response: T) -> Unit) : Unit = noImpl
     //fun post(url:String, data:Any?, handler:()->Unit, type:String = "json") : Unit = noImpl
     //fun ajax(url:String, type:String, contentType:String, dataType:String, data:Any, success:()->Unit) : Unit = noImpl
     fun ajax<RESULT>(request:AjaxRequest<RESULT>) : Unit = noImpl
@@ -15,7 +15,7 @@ trait JQAjax {
 native("$") public var ajaxJQuery: JQAjax = null!!
 
 
-public fun <T> ajaxGet(url:String, loaded:(response:T?) -> Unit) : Unit {
+public fun <T> ajaxGet(url:String, loaded:(response:T) -> Unit) : Unit {
     ajaxJQuery.get(url = url, loaded = loaded)
 }
 

--- a/src/main/kotlin/net/yested/bootstrap/TagsInputField.kt
+++ b/src/main/kotlin/net/yested/bootstrap/TagsInputField.kt
@@ -39,7 +39,10 @@ private fun tagsInputBeforeEventHandler<T>(event: TagsInputBeforeEvent<T>, func:
 public class TagsInputField<T>(val textFactory: (T) -> String = {it.toString()},
                                val typeFactory: (T) -> TagsInputFieldType = {TagsInputFieldType.DEFAULT},
                                val idFactory: (T) -> Any = {it},
-                               inputSize: InputSize = InputSize.DEFAULT) : InputField(inputSize, placeholder = null, type = "text"){
+                               inputSize: InputSize = InputSize.DEFAULT) : InputField<Array<T>>(inputSize, placeholder = null, type = "text"){
+    override var data: Array<T>
+        get() = tags
+        set(value) {tags = value}
 
     public var maxTagCount: Int? = null
     public var onAddExistingTag: (T, JQuery) -> Unit = {item, jqTag -> jqTag.hide {jqTag.fadeIn(400, {})}}
@@ -68,6 +71,10 @@ public class TagsInputField<T>(val textFactory: (T) -> String = {it.toString()},
 
     public fun removeAll() {
         jq(this.element).tagsinput("removeAll")
+    }
+
+    override fun clear() {
+        removeAll()
     }
 
     public fun focus() {

--- a/src/main/kotlin/net/yested/bootstrap/form.kt
+++ b/src/main/kotlin/net/yested/bootstrap/form.kt
@@ -31,6 +31,8 @@ package net.yested.bootstrap
 import net.yested.HTMLComponent
 import net.yested.Span
 import net.yested.with
+import net.yested.ObservableInput
+import net.yested.InputComponent
 
 public trait ValidatorI {
     fun onchange(invoke:(valid:Boolean)->Unit)
@@ -38,7 +40,7 @@ public trait ValidatorI {
     val errorText:String
 }
 
-public class Validator<T>(val inputElement: InputElement<T>, override val errorText:String, val validator:(value:T)->Boolean) : ValidatorI {
+public class Validator<T>(val inputElement: InputComponent<T>, override val errorText:String, val validator:(value:T)->Boolean) : ValidatorI {
 
     private val onChangeListeners: java.util.ArrayList<Function1<Boolean, Unit>> = java.util.ArrayList();
 
@@ -54,7 +56,7 @@ public class Validator<T>(val inputElement: InputElement<T>, override val errorT
     }
 
     private fun revalidate():Boolean =
-        validator(inputElement.value) with {
+        validator(inputElement.data) with {
             for (listener in onChangeListeners) {
                 listener(this)
             }

--- a/src/main/kotlin/net/yested/bootstrap/inputs.kt
+++ b/src/main/kotlin/net/yested/bootstrap/inputs.kt
@@ -20,10 +20,11 @@ import kotlin.js.dom.html.HTMLElement
 import net.yested.createElement
 import net.yested.appendComponent
 import net.yested.BooleanAttribute
-
-native trait HTMLInputElementWithOnChange : HTMLInputElement {
-    public native var onchange: () -> Unit
-}
+import net.yested.InputComponent
+import net.yested.CheckBox
+import net.yested.ObservableInput
+import net.yested.onchange
+import net.yested.InputElementComponent
 
 public enum class InputSize(val code:String) {
     DEFAULT: InputSize("")
@@ -31,45 +32,16 @@ public enum class InputSize(val code:String) {
     SMALL: InputSize("input-sm")
 }
 
-public trait InputElement<T> {
-    fun addOnChangeListener(invoke:()->Unit)
-    fun addOnChangeLiveListener(invoke:()->Unit)
-    var value:T
-    var disabled:Boolean
-    var readonly:Boolean
-    fun decorate(valid:Boolean)
-}
+public abstract class InputField<T>(val inputSize: InputSize = InputSize.DEFAULT, placeholder:String? = null, type: String) : InputElementComponent<T>() {
 
-public trait InputComponent<T> : InputElement<T>, Component
+    override val element: HTMLInputElement = createElement("input") as HTMLInputElement
 
-public open class InputField(val inputSize: InputSize = InputSize.DEFAULT, placeholder:String? = null, type: String = "text") : InputComponent<String> {
+    public var id: String by Attribute();
 
-    override val element: HTMLElement = createElement("input")
-
-    public var id: String by Attribute()
-
-    override var disabled:Boolean by BooleanAttribute()
-    override var readonly:Boolean by BooleanAttribute()
-
-    protected val onChangeListeners: ArrayList<Function0<Unit>> = ArrayList();
-    private val onChangeLiveListeners: ArrayList<Function0<Unit>> = ArrayList();
 
     {
         element.setAttribute("class", "form-control ${inputSize.code}")
-        (element as HTMLInputElementWithOnChange).onchange = {
-            onChangeListeners.forEach { it() }
-            onChangeLiveListeners.forEach { it() }
-        }
-        element.onkeyup = {
-            onChangeLiveListeners.forEach { it() }
-        }
     }
-
-    override var value:String
-        get():String = (element as HTMLInputElement).value
-        set(value:String) {
-            (element as HTMLInputElement).value = value
-        }
 
     override fun decorate(valid: Boolean) {
         element.setAttribute("class", if (valid) "form-control" else "form-control has-error")
@@ -81,67 +53,83 @@ public open class InputField(val inputSize: InputSize = InputSize.DEFAULT, place
             element.setAttribute("placeholder", placeholder)
         }
     }
-
-    override fun addOnChangeListener(invoke: () -> Unit) {
-        onChangeListeners.add(invoke)
-    }
-
-    override fun addOnChangeLiveListener(invoke: () -> Unit) {
-        onChangeLiveListeners.add(invoke)
-    }
-
 }
 
-public fun HTMLComponent.inputField(placeholder: String? = null, init: InputField.() -> Unit):Unit {
+public class StringInputField(inputSize: InputSize = InputSize.DEFAULT, placeholder:String? = null) :
+        InputField<String>(inputSize, placeholder, type = "text") {
+
+    override fun clear() {
+        data = ""
+    }
+
+    override var data: String
+        get() = value
+        set(value) {this.value = value}
+}
+
+public class IntInputField(inputSize: InputSize = InputSize.DEFAULT, placeholder:String? = null) :
+        InputField<Int?>(inputSize, placeholder, type = "number") {
+
+    override fun clear() {
+        data = null
+    }
+
+    override var data: Int?
+        get() = if (value.isEmpty()) null else parseInt(value)
+        set(value) {this.value = if (value == null) "" else value.toString()}
+}
+
+public class FloatInputField(inputSize: InputSize = InputSize.DEFAULT, placeholder:String? = null) :
+        InputField<Float?>(inputSize, placeholder, type = "number") {
+    override fun clear() {
+        data = null
+    }
+
+    override var data: Float?
+        get() = if (value.isEmpty()) null else safeParseDouble(value)?.toFloat() ?: error("cannot convert $value to Float")
+        set(value) {this.value = if (value == null) "" else value.toString()}
+}
+
+public class ColorInputField(inputSize: InputSize = InputSize.DEFAULT, placeholder:String? = null) :
+        InputField<String?>(inputSize, placeholder, type = "color") {
+    override fun clear() {
+        data = null
+    }
+
+    override var data: String?
+        get() = value
+        set(value) {this.value = value ?: ""
+        }
+}
+
+/*public fun HTMLComponent.inputField(placeholder: String? = null, init: InputField.() -> Unit):Unit {
     +(InputField(placeholder = placeholder) with  { init() })
-}
+}*/
 
-public class BtsCheckBox(private val label:HTMLComponent.()->Unit) : Component, InputElement<Boolean> {
+public class BtsCheckBox(private val label:HTMLComponent.()->Unit) : CheckBox() {
 
-    private val inputCheckbox : HTMLInputElementWithOnChange = (createElement("input") with {
+    private val inputCheckbox = (createElement("input") with {
                                                                     setAttribute("type", "checkbox")
-                                                                }) as HTMLInputElementWithOnChange
+                                                                }) as HTMLInputElement
 
-    override val element: HTMLElement =
-            createElement("div") with {
+    override val element =
+            (createElement("div") with {
                 setAttribute("class", "checkbox")
                 appendChild(createElement("label") with {
                     appendChild(inputCheckbox)
                     appendChild((Span() with label).element)
                 })
-            }
+            }) as HTMLInputElement
 
-    override var disabled:Boolean by BooleanAttribute(element = inputCheckbox)
-    override var readonly:Boolean by BooleanAttribute(element = inputCheckbox)
+    public override var disabled:Boolean
+        get() = inputCheckbox.disabled
+        set(value) { inputCheckbox.disabled = value }
 
-    private val onChangeListeners: ArrayList<Function0<Unit>> = ArrayList();
-    private val onChangeLiveListeners: ArrayList<Function0<Unit>> = ArrayList();
-
-    {
-        inputCheckbox.onchange = {
-            onChangeListeners.forEach { it() }
-            onChangeLiveListeners.forEach { it() }
-        }
-    }
-
-    override var value:Boolean
+    override var checked: Boolean
         get():Boolean = inputCheckbox.checked
         set(value:Boolean) {
             inputCheckbox.checked = value
         }
-
-    override fun decorate(valid: Boolean) {
-        //element.setAttribute("class", if (valid) "form-control" else "form-control has-error")
-    }
-
-    override fun addOnChangeListener(invoke: () -> Unit) {
-        onChangeListeners.add(invoke)
-    }
-
-    override fun addOnChangeLiveListener(invoke: () -> Unit) {
-        onChangeLiveListeners.add(invoke)
-    }
-
 }
 
 public fun HTMLComponent.btsCheckBox(label:HTMLComponent.()->Unit):Unit {
@@ -150,27 +138,26 @@ public fun HTMLComponent.btsCheckBox(label:HTMLComponent.()->Unit):Unit {
 
 private data class SelectOption<TT>(val tag:HTMLOptionElement, val value:TT)
 
-public class Select<T>(val data:List<T>, val inputSize: InputSize = InputSize.DEFAULT, multiple:Boolean = false, size:Int = 1, val renderer:(T)->String) : InputComponent<T> {
+public class Select<T>(val options: List<T>, val inputSize: InputSize = InputSize.DEFAULT, multiple:Boolean = false, size:Int = 1, val renderer:(T)->String) : ObservableInput<T>() {
 
-    override val element: HTMLElement = createElement("select")
+    override val element: HTMLSelectElement = createElement("select") as HTMLSelectElement
 
-    override public var disabled:Boolean by BooleanAttribute()
-    override public var readonly:Boolean by BooleanAttribute()
-
-    private val onChangeListeners: ArrayList<Function0<Unit>> = ArrayList();
-
-    private var selectedItemsInt:List<T> = listOf()
+    private var selectedItemsInt:List<T> = emptyList()
 
     private var optionTags:ArrayList<SelectOption<T>> = ArrayList()
 
     private var callbackIsInvoked = false
 
-    public var selectedItems:List<T>
+    public var selectedItems: List<T>
         get() = optionTags.filter { it.tag.selected }.map { it.value }
         set(newData) {
             selectThese(newData)
             changeSelected()
         }
+
+    override fun clear() {
+        selectedItems = emptyList()
+    }
 
     {
         element.setAttribute("class", "form-control ${inputSize.code}")
@@ -179,7 +166,7 @@ public class Select<T>(val data:List<T>, val inputSize: InputSize = InputSize.DE
         if (multiple) {
             element.setAttribute("multiple", "multiple")
         }
-        (element as HTMLInputElementWithOnChange).onchange = { changeSelected() }
+        (element).onchange = { changeSelected() }
     }
 
     private fun changeSelected() {
@@ -199,8 +186,8 @@ public class Select<T>(val data:List<T>, val inputSize: InputSize = InputSize.DE
 
     private fun generateOptions() {
         optionTags =  ArrayList()
-        selectedItemsInt = listOf()
-        data.forEach {
+        selectedItemsInt = emptyList()
+        options.forEach {
             val optionTag = HTMLComponent("option") with { +renderer(it) }
             val value:T = it
             val selectOption = SelectOption(tag = optionTag.element as HTMLOptionElement, value = value)
@@ -209,15 +196,7 @@ public class Select<T>(val data:List<T>, val inputSize: InputSize = InputSize.DE
         }
     }
 
-    override public fun addOnChangeListener(invoke: () -> Unit) {
-        onChangeListeners.add(invoke)
-    }
-
-    override fun addOnChangeLiveListener(invoke: () -> Unit) {
-        throw UnsupportedOperationException()
-    }
-
-    override var value: T
+    override public var data: T
         get() = selectedItems.first()
         set(value) {
             selectedItems = listOf(value)
@@ -235,7 +214,7 @@ public class Select<T>(val data:List<T>, val inputSize: InputSize = InputSize.DE
 <div class="input-group-addon">.00</div>
 </div>
  */
-public fun HTMLComponent.inputAddOn(prefix:String? = null, suffix:String? = null, textInput : InputField):Unit =
+public fun HTMLComponent.inputAddOn<T>(prefix:String? = null, suffix:String? = null, textInput : InputField<T>):Unit =
     +(
         div(clazz = "input-group") {
             prefix?.let {

--- a/src/main/kotlin/net/yested/bootstrap/smartgrid/config.kt
+++ b/src/main/kotlin/net/yested/bootstrap/smartgrid/config.kt
@@ -10,6 +10,8 @@ import net.yested.bootstrap.btsButton
 import net.yested.ButtonType
 import net.yested.bootstrap.ButtonLook
 import net.yested.bootstrap.ButtonSize
+import net.yested.TextInput
+import net.yested.bootstrap.StringInputField
 
 /**
  * Opens configuration dialog for SmartGrid
@@ -41,7 +43,7 @@ fun <T> openConfigurationDialog(
         onclick = { checkbox.checked = !checkbox.checked }
     }
 
-    val inputField = InputField()
+    val inputField = StringInputField()
 
     fun setColumnsData() {
         val text = inputField.value.toLowerCase()


### PR DESCRIPTION
- A tried to hide the "type" field of the InputField element behind concrete Types, like StringInputField, IntInputField etc.
- I modified he hierarchy tree of InputFields in order that the following HTML components be treated as InputFields: Select, TextField, TextArea, Checkbox.  
All of these components holds some value in their "data" field. This value is type-safe. 
- These components got a "clean" method, which set their data into the default value.
- I removed HTMLInputElementWithOnChange trait, and introduce the onchange field as a extension property of HTMLElement